### PR TITLE
NEP-2624: Null blob crash fix

### DIFF
--- a/Sources/MPDB.m
+++ b/Sources/MPDB.m
@@ -211,8 +211,12 @@
                     NSError *error;
                     NSMutableDictionary *jsonObject = [NSJSONSerialization JSONObjectWithData:blob options:NSJSONReadingMutableContainers error:&error];
                     jsonObject[@"id"] = [NSNumber numberWithInt:eId];
-                    [rows addObject:jsonObject];
-                    rowsRead++;
+                    if (jsonObject) {
+                        [rows addObject:jsonObject];
+                        rowsRead++;
+                    } else {
+                        MPLogError(@"Failed to parse blob data in %@: %@", tableName, error);
+                    }
                 } else {
                     [self logSqlError:[NSString stringWithFormat:@"No blob found in data column for row in %@", tableName]];
                 }


### PR DESCRIPTION
Should fix the crash when blob data in DB can't be parsed.
Can't reproduce so the fix is just an assumption that it will help.